### PR TITLE
Fix @rpath reference for macOS

### DIFF
--- a/kernels/CMakeLists.txt
+++ b/kernels/CMakeLists.txt
@@ -350,7 +350,7 @@ target_include_directories(embree PUBLIC
 # libtbb is located in same install folder as libembree
 IF(WIN32)
 ELSEIF(APPLE)
-  SET_TARGET_PROPERTIES(embree PROPERTIES INSTALL_RPATH "@rpath") # On MacOSX the app is supposed to already have an rpath set to that folder
+  SET_TARGET_PROPERTIES(embree PROPERTIES INSTALL_RPATH "@loader_path") # On MacOSX we tell dyld to find libtbb in the folder libembree is placed.
 ELSE()
   SET_TARGET_PROPERTIES(embree PROPERTIES INSTALL_RPATH "$ORIGIN")  # Linux we tell ld to find libtbb in the folder libembree is placed.
 ENDIF()


### PR DESCRIPTION
The semantic equivalent of `$ORIGIN` on macOS is `@loader_path`. That seems to be the intent here, so let's use `@loader_path` instead of `@rpath`.

Setting an RPATH of `@rpath` is, in any case, non-sensical. An `@rpath` reference tells dyld (the dynamic loader) to use the known RPATHs to resolve the reference, so adding `@rpath` to the list of known RPATHs doesn't give dyld any more information than it already has.