### PR TITLE
Ensure that a user-defined thread count takes precedence over getNumberOfLogicalThreads()

### DIFF
--- a/common/tasking/taskschedulerinternal.cpp
+++ b/common/tasking/taskschedulerinternal.cpp
@@ -150,7 +150,8 @@ namespace embree
   {
     Lock<MutexSys> lock(g_mutex);
     assert(newNumThreads);
-    newNumThreads = min(newNumThreads, (size_t) getNumberOfLogicalThreads());
+    if (newNumThreads == std::numeric_limits<size_t>::max())
+      newNumThreads = (size_t) getNumberOfLogicalThreads();
 
     numThreads = newNumThreads;
     if (!startThreads && !running) return;
@@ -230,7 +231,8 @@ namespace embree
   TaskScheduler::TaskScheduler()
     : threadCounter(0), anyTasksRunning(0), hasRootTask(false)
   {
-    threadLocal.resize(2*getNumberOfLogicalThreads()); // FIXME: this has to be 2x as in the compatibility join mode with rtcCommitScene the worker threads also join. When disallowing rtcCommitScene to join a build we can remove the 2x.
+    assert(threadPool);
+    threadLocal.resize(2 * TaskScheduler::threadCount()); // FIXME: this has to be 2x as in the compatibility join mode with rtcCommitScene the worker threads also join. When disallowing rtcCommitScene to join a build we can remove the 2x.
     for (size_t i=0; i<threadLocal.size(); i++)
       threadLocal[i].store(nullptr);
   }


### PR DESCRIPTION
Hi,

This pull request ensures that a user-defined thread count (i.e., in the device's config argument) consistently takes precedence over the detected number of logical threads. Previously, Embree would fail if the user-provided thread count was larger than the internally determined one. It internally allocated threading related buffers based on the return value of `getNumberOfLogicalThreads()`, which would then cause a segfault when invoking `rtcJoinCommitScene` using a thread pool that has a larger number of threads. Concretely, I encountered this when running Mitsuba 3 on a cluster setup. Currently, Embree effectively requires the user thread pool to be smaller or equal to `getNumberOfLogicalThreads()`, but this is not always straightforward to guarantee. Moreover, I would argue that this is neither documented nor immediately obvious for users.

This fix seems to work for me, but I am open to suggestions if it is not general enough to be merged in this state. 

Best,
Delio