### PR TITLE
Add alignment definitions to RTCHitNt and RTCRayNt

### DIFF
--- a/include/embree4/rtcore_ray.h
+++ b/include/embree4/rtcore_ray.h
@@ -225,8 +225,8 @@ RTC_FORCEINLINE RTCRayN* RTCRayHitN_RayN(RTCRayHitN* rayhit, unsigned int N) { r
 RTC_FORCEINLINE RTCHitN* RTCRayHitN_HitN(RTCRayHitN* rayhit, unsigned int N) { return (RTCHitN*)&((float*)rayhit)[12*N]; }
 
 /* Helper structure for a ray packet of compile-time size N */
-template<int N>
-struct RTCRayNt
+template<unsigned int N>
+struct RTC_ALIGN((N && !(N & (N - 1)) ? (N * 4 > 16 ? N * 4 : 16) : 16)) RTCRayNt
 {
   float org_x[N];
   float org_y[N];
@@ -245,8 +245,8 @@ struct RTCRayNt
 };
 
 /* Helper structure for a hit packet of compile-time size N */
-template<int N>
-struct RTCHitNt
+template<unsigned int N>
+struct RTC_ALIGN((N && !(N & (N - 1)) ? (N * 4 > 16 ? N * 4 : 16) : 16)) RTCHitNt
 {
   float Ng_x[N];
   float Ng_y[N];


### PR DESCRIPTION
Alignment definitions should be added to RTCHitNt and RTCRayNt templates so they match the C definitions provided. The following static assertions demonstrate the issues with using the RTCRayNt templates as they all fail because RTCRayNt has an alignment of 4, equivalent to alignof(float).
```
static_assert(alignof(embree::RTCRayNt<1>) == alignof(embree::RTCRay));
static_assert(alignof(embree::RTCRayNt<4>) == alignof(embree::RTCRay4));
static_assert(alignof(embree::RTCRayNt<8>) == alignof(embree::RTCRay8));
static_assert(alignof(embree::RTCRayNt<16>) == alignof(embree::RTCRay16));
```

As the alignment calculation in the PR is nasty as it avoids requiring the alignof keyword, or constexpr functions, this could instead be hidden behind a macro. Maybe RTC_ALIGN_SOA_AT_LEAST(N, MIN)?

The code is equivalent to:
```
constexpr std::size_t AlignSOAAtLeast(unsigned N, std::size_t min_alignment) noexcept {
    if (std::has_single_bit<unsigned>(N)) {
        return std::max<std::size_t>(min_alignment, N * alignof(float));
    } else {
        return min_alignment;
    }
}
```
