### PR TITLE
Fix compiling for Arm64 Windows with MSVC

### DIFF
--- a/common/math/emath.h
+++ b/common/math/emath.h
@@ -15,6 +15,10 @@
 #if defined(__ARM_NEON)
 #include "../simd/arm/emulation.h"
 #else
+#if defined(_M_ARM64)
+// Windows MSVC allows for *mmintrin.h on Arm64 but only with USE_SOFT_INTRINSICS.
+#define USE_SOFT_INTRINSICS
+#endif
 #include <emmintrin.h>
 #include <xmmintrin.h>
 #include <immintrin.h>

--- a/common/sys/intrinsics.h
+++ b/common/sys/intrinsics.h
@@ -12,6 +12,10 @@
 #if defined(__ARM_NEON)
 #include "../simd/arm/emulation.h"
 #else
+#if defined(_M_ARM64)
+// Windows MSVC allows for immintrin.h on Arm64 but only with USE_SOFT_INTRINSICS.
+#define USE_SOFT_INTRINSICS
+#endif
 #include <immintrin.h>
 #if defined(__EMSCRIPTEN__)
 #include "../simd/wasm/emulation.h"
@@ -89,15 +93,13 @@ namespace embree
 #endif
   }
   
-#if defined(__X86_64__) || defined (__aarch64__)
-  __forceinline size_t bsf(size_t v) {
+  __forceinline uint64_t bsf(uint64_t v) {
 #if defined(__AVX2__) 
     return _tzcnt_u64(v);
 #else
     unsigned long r = 0; _BitScanForward64(&r,v); return r;
 #endif
   }
-#endif
   
   __forceinline int bscf(int& v) 
   {
@@ -113,14 +115,12 @@ namespace embree
     return i;
   }
   
-#if defined(__X86_64__) || defined (__aarch64__)
-  __forceinline size_t bscf(size_t& v) 
+  __forceinline uint64_t bscf(uint64_t& v) 
   {
-    size_t i = bsf(v);
+    uint64_t i = bsf(v);
     v &= v-1;
     return i;
   }
-#endif
   
   __forceinline int bsr(int v) {
 #if defined(__AVX2__)  && !defined(__aarch64__)
@@ -138,15 +138,13 @@ namespace embree
 #endif
   }
   
-#if defined(__X86_64__) || defined (__aarch64__)
-  __forceinline size_t bsr(size_t v) {
+  __forceinline uint64_t bsr(uint64_t v) {
 #if defined(__AVX2__) 
     return 63 -_lzcnt_u64(v);
 #else
     unsigned long r = 0; _BitScanReverse64(&r, v); return r;
 #endif
   }
-#endif
   
   __forceinline int lzcnt(const int x)
   {

--- a/common/sys/platform.h
+++ b/common/sys/platform.h
@@ -58,7 +58,7 @@
 #endif
 
 /* detect 64 bit platform */
-#if defined(__X86_64__) || defined(__aarch64__)
+#if UINTPTR_MAX == UINT64_MAX
 #define __64BIT__
 #endif
 


### PR DESCRIPTION
This PR fixes 3 issues when compiling for Arm64 Windows with MSVC.

* Fix detection of being a 64-bit platform. I replaced the `defined(__X86_64__) || defined(__aarch64__)` check with a platform-agnostic `UINTPTR_MAX == UINT64_MAX` that relies on `stdint.h` (please let me know if any of Embree's targets do not have `stdint.h`, my assumption is that this is fine to depend on, but I know that MSVC versions from before 2010 don't have it). MSVC does not define `__aarch64__`, but it does define `_M_ARM64`. Adding ` || defined(_M_ARM64)` would also fix the problem, but it's best to make this platform-agnostic.
* Always define unsigned 64-bit versions of `bsf`, `bscf`, and `bsr`. Without it, this function was not being defined on MSVC. Same as the above point, MSVC does not define `__aarch64__`, but it does define `_M_ARM64`. Adding ` || defined(_M_ARM64)` would also fix the problem, but it's best to make this platform-agnostic. Using `size_t` with `#if` guards for 64-bit is the same as just using `uint64_t`. Note that functions may be automatically removed by the compiler if unused, so there is no reason to explicitly wrap it in `#if` guards.
* Before `#include <immintrin.h>`, check if `_M_ARM64` is defined (meaning Arm64 Windows MSVC) and if so define `USE_SOFT_INTRINSICS`. MSVC provides `immintrin.h` with software support on Arm64, but this has to be enabled explicitly. The MSVC-provided `immintrin.h` contains this code:

```cpp
#if !defined(_M_IX86) && !defined(_M_X64) && !(defined(_M_ARM64) && defined(USE_SOFT_INTRINSICS))
#error This header is specific to X86, X64, ARM64, and ARM64EC targets
#endif
```