### PR TITLE
Suppressed warnings with latest clang/sycl compiler

### DIFF
--- a/tutorials/common/image/image.h
+++ b/tutorials/common/image/image.h
@@ -54,7 +54,7 @@ namespace embree
       : Image(width,height,name)
     {
       data = new T[width*height];
-      memset(data,0,width*height*sizeof(T));
+      memset((void*)data,0,width*height*sizeof(T));
     }
 
     /*! create image of constant color */

--- a/tutorials/common/imgui/imgui.cpp
+++ b/tutorials/common/imgui/imgui.cpp
@@ -930,6 +930,7 @@ CODE
 #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"  // warning: zero as null pointer constant                    // some standard header variations use #define NULL 0
 #pragma clang diagnostic ignored "-Wdouble-promotion"               // warning: implicit conversion from 'float' to 'double' when passing argument to function  // using printf() is a misery with this as C++ va_arg ellipsis changes float to double.
 #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"  // warning: implicit conversion from 'xxx' to 'float' may lose precision
+#pragma clang diagnostic ignored "-Wnontrivial-memaccess"           // warning: first argument in call to 'memset' is a pointer to non-trivially copyable type
 #elif defined(__GNUC__)
 // We disable -Wpragmas because GCC doesn't provide a has_warning equivalent and some forks/patches may not follow the warning/version association.
 #pragma GCC diagnostic ignored "-Wpragmas"                  // warning: unknown option after '#pragma GCC diagnostic' kind

--- a/tutorials/common/imgui/imgui.h
+++ b/tutorials/common/imgui/imgui.h
@@ -118,6 +118,7 @@ Index of this file:
 #pragma clang diagnostic ignored "-Wold-style-cast"
 #if __has_warning("-Wzero-as-null-pointer-constant")
 #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#pragma clang diagnostic ignored "-Wnontrivial-memaccess"           // warning: first argument in call to 'memset' is a pointer to non-trivially copyable type
 #endif
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push

--- a/tutorials/common/imgui/imgui_draw.cpp
+++ b/tutorials/common/imgui/imgui_draw.cpp
@@ -64,6 +64,7 @@ Index of this file:
 #pragma clang diagnostic ignored "-Wreserved-id-macro"              // warning: macro name is a reserved identifier
 #pragma clang diagnostic ignored "-Wdouble-promotion"               // warning: implicit conversion from 'float' to 'double' when passing argument to function  // using printf() is a misery with this as C++ va_arg ellipsis changes float to double.
 #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"  // warning: implicit conversion from 'xxx' to 'float' may lose precision
+#pragma clang diagnostic ignored "-Wnontrivial-memaccess"           // warning: first argument in call to 'memset' is a pointer to non-trivially copyable type
 #elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wpragmas"                  // warning: unknown option after '#pragma GCC diagnostic' kind
 #pragma GCC diagnostic ignored "-Wunused-function"          // warning: 'xxxx' defined but not used

--- a/tutorials/common/imgui/imgui_internal.h
+++ b/tutorials/common/imgui/imgui_internal.h
@@ -87,6 +87,7 @@ Index of this file:
 #pragma clang diagnostic ignored "-Wdouble-promotion"
 #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"  // warning: implicit conversion from 'xxx' to 'float' may lose precision
 #pragma clang diagnostic ignored "-Wmissing-noreturn"               // warning: function 'xxx' could be declared with attribute 'noreturn'
+#pragma clang diagnostic ignored "-Wnontrivial-memaccess"           // warning: first argument in call to 'memset' is a pointer to non-trivially copyable type
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpragmas"              // warning: unknown option after '#pragma GCC diagnostic' kind

--- a/tutorials/common/imgui/imgui_tables.cpp
+++ b/tutorials/common/imgui/imgui_tables.cpp
@@ -229,6 +229,7 @@ Index of this file:
 #pragma clang diagnostic ignored "-Wenum-enum-conversion"           // warning: bitwise operation between different enumeration types ('XXXFlags_' and 'XXXFlagsPrivate_')
 #pragma clang diagnostic ignored "-Wdeprecated-enum-enum-conversion"// warning: bitwise operation between different enumeration types ('XXXFlags_' and 'XXXFlagsPrivate_') is deprecated
 #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"  // warning: implicit conversion from 'xxx' to 'float' may lose precision
+#pragma clang diagnostic ignored "-Wnontrivial-memaccess"           // warning: first argument in call to 'memset' is a pointer to non-trivially copyable type
 #elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wpragmas"                          // warning: unknown option after '#pragma GCC diagnostic' kind
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"                // warning: format not a string literal, format string not checked

--- a/tutorials/common/imgui/imgui_widgets.cpp
+++ b/tutorials/common/imgui/imgui_widgets.cpp
@@ -77,6 +77,7 @@ Index of this file:
 #pragma clang diagnostic ignored "-Wenum-enum-conversion"           // warning: bitwise operation between different enumeration types ('XXXFlags_' and 'XXXFlagsPrivate_')
 #pragma clang diagnostic ignored "-Wdeprecated-enum-enum-conversion"// warning: bitwise operation between different enumeration types ('XXXFlags_' and 'XXXFlagsPrivate_') is deprecated
 #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"  // warning: implicit conversion from 'xxx' to 'float' may lose precision
+#pragma clang diagnostic ignored "-Wnontrivial-memaccess"           // warning: first argument in call to 'memset' is a pointer to non-trivially copyable type
 #elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wpragmas"                          // warning: unknown option after '#pragma GCC diagnostic' kind
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"                // warning: format not a string literal, format string not checked

--- a/tutorials/common/tutorial/scene_device.cpp
+++ b/tutorials/common/tutorial/scene_device.cpp
@@ -57,14 +57,14 @@ namespace embree
   template<typename Ty>
   Ty* copyArrayToUSM(const avector<Ty>& in) {
     Ty* out = (Ty*)alignedUSMMalloc(in.size()*sizeof(Ty));
-    memcpy(out,in.data(),in.size()*sizeof(Ty));
+    memcpy((void*)out,in.data(),in.size()*sizeof(Ty));
     return out;
   }
 
   template<typename Ty>
   Ty* copyArrayToUSM(const std::vector<Ty>& in) {
     Ty* out = (Ty*)alignedUSMMalloc(in.size()*sizeof(Ty));
-    memcpy(out,in.data(),in.size()*sizeof(Ty));
+    memcpy((void*)out,in.data(),in.size()*sizeof(Ty));
     return out;
   }
 

--- a/tutorials/intersection_filter/intersection_filter_device.cpp
+++ b/tutorials/intersection_filter/intersection_filter_device.cpp
@@ -269,7 +269,7 @@ unsigned int addCube (RTCScene scene_i, const Vec3fa& offset, const Vec3fa& scal
   }
   //rtcSetSharedGeometryBuffer(geom, RTC_BUFFER_TYPE_INDEX, 0, RTC_FORMAT_UINT3, cube_tri_indices, 0, 3*sizeof(unsigned int), NUM_TRI_FACES);
   Vec3i* index = (Vec3i*)rtcSetNewGeometryBuffer(geom, RTC_BUFFER_TYPE_INDEX, 0, RTC_FORMAT_UINT3, 3*sizeof(unsigned int), NUM_TRI_FACES);
-  memcpy(index, cube_tri_indices, 3*sizeof(unsigned int) * NUM_TRI_FACES);
+  memcpy((void*)index, cube_tri_indices, 3*sizeof(unsigned int) * NUM_TRI_FACES);
 
   /* create per-triangle color array */
   data.colors = (Vec3fa*) alignedUSMMalloc((12)*sizeof(Vec3fa),16);


### PR DESCRIPTION
warning: first argument in call to 'memset' is a pointer to non-trivially copyable type