### PR TITLE
Add missing RTC_NAMESPACE definition to rtcore_config

### DIFF
--- a/kernels/rtcore_config.h.in
+++ b/kernels/rtcore_config.h.in
@@ -39,6 +39,7 @@
 #  define RTC_API_EXTERN_CPP
 #  undef EMBREE_API_NAMESPACE
 #else
+#  define RTC_NAMESPACE
 #  define RTC_NAMESPACE_BEGIN
 #  define RTC_NAMESPACE_END
 #  define RTC_NAMESPACE_USE


### PR DESCRIPTION
`rtcore_config.h.in does` not define `RTC_NAMESPACE` when `EMBREE_API_NAMESPACE` is not defined when it should be defined but empty. This can cause a problem with forward declarations like the following:
```c++
RTC_NAMESPACE_BEGIN
typedef struct RTCSceneTy* RTCScene;
RTC_NAMESPACE_END

void my_function(RTC_NAMESPACE::RTCScene scene);
```