### PR TITLE
Fixed compilation with internal task scheduler

### DIFF
--- a/common/tasking/taskschedulerinternal.cpp
+++ b/common/tasking/taskschedulerinternal.cpp
@@ -8,8 +8,6 @@
 
 namespace embree
 {
-  RTC_NAMESPACE_BEGIN
-  
   static MutexSys g_mutex;
   size_t TaskScheduler::g_numThreads = 0;
   __thread TaskScheduler* TaskScheduler::g_instance = nullptr;
@@ -399,6 +397,4 @@ namespace embree
   dll_export void TaskScheduler::removeScheduler(const Ref<TaskScheduler>& scheduler) {
     threadPool->remove(scheduler);
   }
-
-  RTC_NAMESPACE_END
 }

--- a/common/tasking/taskschedulerinternal.h
+++ b/common/tasking/taskschedulerinternal.h
@@ -18,11 +18,6 @@
 
 namespace embree
 {
-
-  /* The tasking system exports some symbols to be used by the tutorials. Thus we 
-     hide is also in the API namespace when requested. */
-  RTC_NAMESPACE_BEGIN
-
   struct TaskScheduler : public RefCount
   {
     ALIGNED_STRUCT_(64);
@@ -375,10 +370,4 @@ namespace embree
     static __thread Thread* thread_local_thread;
     static ThreadPool* threadPool;
   };
-
-  RTC_NAMESPACE_END
-
-#if defined(RTC_NAMESPACE)
-    using RTC_NAMESPACE::TaskScheduler;
-#endif
 }


### PR DESCRIPTION
Internal task scheduler is now outside of RTC namespace matching the other schedulers.