### PR TITLE
Fix unnecessary string copies in verify tests

### DIFF
--- a/tutorials/verify/verify.cpp
+++ b/tutorials/verify/verify.cpp
@@ -51,7 +51,7 @@ namespace embree
     return (cpu_features & isa) == isa;
   }
 
-  bool regex_match(std::string str, std::string regex)
+  bool regex_match(const std::string& str, const std::string& regex)
   {
 #if (defined(__INTEL_COMPILER) && (__INTEL_COMPILER < 1600)) // works around __ZTVNSt3__123__match_any_but_newlineIcEE link error
     return str == regex; 
@@ -5714,7 +5714,7 @@ namespace embree
   struct SimpleBenchmark : public VerifyApplication::Benchmark
   {
     SimpleBenchmark (std::string name, int64_t isa)
-      : VerifyApplication::Benchmark(name,isa,"1/s",true,10) {}
+      : VerifyApplication::Benchmark(std::move(name),isa,"1/s",true,10) {}
     
     float benchmark(VerifyApplication* state)
     {
@@ -5730,7 +5730,7 @@ namespace embree
     unsigned int N, dN;
     
     ParallelIntersectBenchmark (std::string name, int64_t isa, unsigned int N, unsigned int dN)
-      : VerifyApplication::Benchmark(name,isa,"Mrps",true,10), N(N), dN(dN) {}
+      : VerifyApplication::Benchmark(std::move(name),isa,"Mrps",true,10), N(N), dN(dN) {}
 
     bool setup(VerifyApplication* state) 
     {
@@ -6076,7 +6076,7 @@ namespace embree
     std::vector<Ref<SceneGraph::Node>> geometries;
     
     CreateGeometryBenchmark (std::string name, int64_t isa, GeometryType gtype, SceneFlags sflags, RTCBuildQuality quality, size_t numPhi, size_t numMeshes, bool update, bool dobenchmark)
-      : VerifyApplication::Benchmark(name,isa,dobenchmark ? "Mprims/s" : "MB",dobenchmark,dobenchmark?10:1), gtype(gtype), sflags(sflags), quality(quality), 
+      : VerifyApplication::Benchmark(std::move(name),isa,dobenchmark ? "Mprims/s" : "MB",dobenchmark,dobenchmark?10:1), gtype(gtype), sflags(sflags), quality(quality), 
         numPhi(numPhi), numMeshes(numMeshes), update(update), dobenchmark(dobenchmark),
         numPrimitives(0), device(nullptr), scene(nullptr) {}
 
@@ -6882,27 +6882,27 @@ namespace embree
       }, "--skip-before <regexpr>: Skips all tests before the first test matching the regular expression.");
     registerOptionAlias("skip-before","disable-before");
 
-    registerOption("flatten", [this] (Ref<ParseStream> cin, const FileName& path) {
+    registerOption("flatten", [this] (const Ref<ParseStream>& cin, const FileName& path) {
         flatten = false;
       }, "--flatten: shows all leaf test names when executing tests");
     
-    registerOption("sequential", [this] (Ref<ParseStream> cin, const FileName& path) {
+    registerOption("sequential", [this] (const Ref<ParseStream>& cin, const FileName& path) {
         parallel = false;
       }, "--sequential: execute all tests sequentially");
 
-    registerOption("parallel", [this] (Ref<ParseStream> cin, const FileName& path) {
+    registerOption("parallel", [this] (const Ref<ParseStream>& cin, const FileName& path) {
         parallel = true;
       }, "--parallel: parallelized test execution (default)");
 
-    registerOption("colors", [this] (Ref<ParseStream> cin, const FileName& path) {
+    registerOption("colors", [this] (const Ref<ParseStream>& cin, const FileName& path) {
         usecolors = true;
       }, "--colors: do use shell colors");
 
-    registerOption("no-colors", [this] (Ref<ParseStream> cin, const FileName& path) {
+    registerOption("no-colors", [this] (const Ref<ParseStream>& cin, const FileName& path) {
         usecolors = false;
       }, "--no-colors: do not use shell colors");
 
-    registerOption("cdash", [this] (Ref<ParseStream> cin, const FileName& path) {
+    registerOption("cdash", [this] (const Ref<ParseStream>& cin, const FileName& path) {
         cdash = true;
       }, "--cdash: prints cdash measurements");
 
@@ -6921,13 +6921,13 @@ namespace embree
       }, "--benchmark-tolerance: maximum relative slowdown to let a test pass");
     registerOptionAlias("benchmark-tolerance","tolerance");
 
-    registerOption("print-tests", [this] (Ref<ParseStream> cin, const FileName& path) {
+    registerOption("print-tests", [this] (const Ref<ParseStream>& cin, const FileName& path) {
         print_tests(tests,0);
         exit(1);
       }, "--print-tests: prints all enabled test names");
     registerOptionAlias("print-tests","print-names");
 
-    registerOption("print-ctests", [this] (Ref<ParseStream> cin, const FileName& path) {
+    registerOption("print-ctests", [this] (const Ref<ParseStream>& cin, const FileName& path) {
         print_ctests(tests,0);
         exit(1);
       }, "--print-ctests: prints all test in a form to add to CMakeLists.txt");
@@ -6938,7 +6938,7 @@ namespace embree
 
     registerOption("plot-over-primitives", [this] (Ref<ParseStream> cin, const FileName& path) {
         std::vector<Ref<Benchmark>> benchmarks;
-        FileName outFileName = parse_benchmark_list(cin,benchmarks);
+        FileName outFileName = parse_benchmark_list(std::move(cin),benchmarks);
         plot(benchmarks,outFileName,"#primitives",1000,1100000,1.2f,0,[&] (Ref<Benchmark> benchmark, size_t& N) {
             N = benchmark->setNumPrimitives(N);
             benchmark->setup(this);
@@ -6951,7 +6951,7 @@ namespace embree
 
     registerOption("plot-over-threads", [this] (Ref<ParseStream> cin, const FileName& path) {
         std::vector<Ref<Benchmark>> benchmarks;
-        FileName outFileName = parse_benchmark_list(cin,benchmarks);
+        FileName outFileName = parse_benchmark_list(std::move(cin),benchmarks);
         plot(benchmarks,outFileName,"#threads",2,getNumberOfLogicalThreads(),1.0f,2,[&] (Ref<Benchmark> benchmark, size_t N) {
             benchmark->setNumThreads(N);
             benchmark->setup(this);
@@ -6968,7 +6968,7 @@ namespace embree
 #endif
   }
 
-  void VerifyApplication::prefix_test_names(Ref<Test> test, std::string prefix)
+  void VerifyApplication::prefix_test_names(Ref<Test> test, const std::string& prefix)
   {
     if (Ref<TestGroup> group = test.dynamicCast<TestGroup>()) 
       for (auto& t : group->tests) 
@@ -7048,13 +7048,13 @@ namespace embree
     }
   }
 
-  void VerifyApplication::enable_disable_all_tests(Ref<Test> test, bool enabled)
+  void VerifyApplication::enable_disable_all_tests(const Ref<Test>& test, bool enabled)
   {
     map_tests(test, [&] (Ref<Test> test) { test->enabled = enabled; });
     update_tests(test);
   }
 
-  size_t VerifyApplication::enable_disable_some_tests(Ref<Test> test, std::string regex, bool enabled)
+  size_t VerifyApplication::enable_disable_some_tests(const Ref<Test>& test, std::string regex, bool enabled)
   {
     size_t N = 0;
     map_tests(test, [&] (Ref<Test> test) { 
@@ -7068,7 +7068,7 @@ namespace embree
   }
 
   template<typename Closure>
-  void VerifyApplication::plot(std::vector<Ref<Benchmark>> benchmarks, const FileName outFileName, std::string xlabel, size_t startN, size_t endN, float f, size_t dn, const Closure& test)
+  void VerifyApplication::plot(std::vector<Ref<Benchmark>> benchmarks, const FileName& outFileName, const std::string& xlabel, size_t startN, size_t endN, float f, size_t dn, const Closure& test)
   {
     std::fstream plot;
     plot.open(outFileName, std::fstream::out | std::fstream::trunc);

--- a/tutorials/verify/verify.cpp
+++ b/tutorials/verify/verify.cpp
@@ -687,7 +687,7 @@ namespace embree
   struct DeviceCreationTest : public VerifyApplication::Test
   {
     DeviceCreationTest (std::string name)
-      : VerifyApplication::Test(name,0,VerifyApplication::TEST_SHOULD_PASS) {}
+      : VerifyApplication::Test(std::move(name),0,VerifyApplication::TEST_SHOULD_PASS) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -701,7 +701,7 @@ namespace embree
   struct EmbreeInternalTest : public VerifyApplication::Test
   {
     EmbreeInternalTest (std::string name, size_t testID)
-      : VerifyApplication::Test(name,0,VerifyApplication::TEST_SHOULD_PASS), testID(testID) {}
+      : VerifyApplication::Test(std::move(name),0,VerifyApplication::TEST_SHOULD_PASS), testID(testID) {}
   
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -764,7 +764,7 @@ namespace embree
   struct MultipleDevicesTest : public VerifyApplication::Test
   {
     MultipleDevicesTest (std::string name, int64_t isa)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -787,7 +787,7 @@ namespace embree
     GeometryType gtype;
 
     GetBoundsTest (std::string name, int64_t isa, GeometryType gtype)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), gtype(gtype) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), gtype(gtype) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -827,7 +827,7 @@ namespace embree
     GeometryType gtype;
 
     GetLinearBoundsTest (std::string name, int64_t isa, GeometryType gtype)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), gtype(gtype) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), gtype(gtype) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -865,7 +865,7 @@ namespace embree
   struct GetUserDataTest : public VerifyApplication::Test
   {
     GetUserDataTest (std::string name, int64_t isa)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS) {}
     
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -917,7 +917,7 @@ namespace embree
     GeometryType gtype;
 
     BufferStrideTest (std::string name, int64_t isa, GeometryType gtype)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), gtype(gtype) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), gtype(gtype) {}
     
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -1024,7 +1024,7 @@ namespace embree
   struct TypesTest : public VerifyApplication::Test
   {
     TypesTest(std::string name, int64_t isa)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS)
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS)
     {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
@@ -1054,7 +1054,7 @@ namespace embree
   struct EmptySceneTest : public VerifyApplication::Test
   {
     EmptySceneTest (std::string name, int64_t isa, SceneFlags sflags)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -1089,7 +1089,7 @@ namespace embree
     RTCBuildQuality quality;
 
     EmptyGeometryTest (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {}
     
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -1123,7 +1123,7 @@ namespace embree
     RTCBuildQuality quality; 
     
     ManyBuildTest (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS,false), sflags(sflags), quality(quality) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS,false), sflags(sflags), quality(quality) {}
     
     VerifyApplication::TestReturnValue run (VerifyApplication* state, bool silent)
     {
@@ -1176,7 +1176,7 @@ namespace embree
     RTCBuildQuality quality; 
 
     BuildTest (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {}
     
     VerifyApplication::TestReturnValue run (VerifyApplication* state, bool silent)
     {
@@ -1213,7 +1213,7 @@ namespace embree
     size_t N;
     
     OverlappingGeometryTest (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality, size_t N)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality), N(N) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality), N(N) {}
     
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -1315,7 +1315,7 @@ namespace embree
     RTCBuildQuality quality;
     
     MemoryConsumptionTest (std::string name, int64_t isa, GeometryType gtype, SceneFlags sflags, RTCBuildQuality quality)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), gtype(gtype), sflags(sflags), quality(quality) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), gtype(gtype), sflags(sflags), quality(quality) {}
 
     static bool memoryMonitor(void* userPtr, const ssize_t bytes, const bool /*post*/)
     {
@@ -1525,7 +1525,7 @@ namespace embree
     SceneFlags sflags;
 
     NewDeleteGeometryTest (std::string name, int64_t isa, SceneFlags sflags)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags) {}
     
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -1593,7 +1593,7 @@ namespace embree
     SceneFlags sflags;
 
     UserGeometryIDTest (std::string name, int64_t isa, SceneFlags sflags)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags) {}
     
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -1647,7 +1647,7 @@ namespace embree
     SceneFlags sflags;
 
     EnableDisableGeometryTest (std::string name, int64_t isa, SceneFlags sflags)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags) {}
     
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -1702,7 +1702,7 @@ namespace embree
     SceneFlags sflags;
 
     DisableAndDetachGeometryTest (std::string name, int64_t isa, SceneFlags sflags)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -1838,7 +1838,7 @@ namespace embree
     RTCBuildQuality quality;
 
     UpdateTest (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality, IntersectMode imode, IntersectVariant ivariant)
-      : VerifyApplication::IntersectTest(name,isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {}
+      : VerifyApplication::IntersectTest(std::move(name),isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {}
     
     static void move_mesh(RTCGeometry mesh, size_t numVertices, Vec3fa& pos) 
     {
@@ -1915,7 +1915,7 @@ namespace embree
   struct GarbageGeometryTest : public VerifyApplication::Test
   {
     GarbageGeometryTest (std::string name, int64_t isa)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS) {}
     
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -2044,7 +2044,7 @@ namespace embree
     unsigned int N;
     
     InterpolateSubdivTest (std::string name, int64_t isa, unsigned int N)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), N(N) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), N(N) {}
 
     bool checkInterpolation2D(RTCGeometry geom, int primID, float u, float v, int v0, RTCBufferType bufferType, unsigned int bufferSlot, float* data, unsigned int N, unsigned int N_total)
     {
@@ -2183,7 +2183,7 @@ namespace embree
     size_t N;
     
     InterpolateTrianglesTest (std::string name, int64_t isa, size_t N)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), N(N) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), N(N) {}
     
     bool checkTriangleInterpolation(RTCGeometry geom, int primID, float u, float v, int v0, int v1, int v2, RTCBufferType bufferType, unsigned int bufferSlot, float* data, size_t N, size_t N_total)
     {
@@ -2279,7 +2279,7 @@ namespace embree
     size_t N;
     
     InterpolateGridTest (std::string name, int64_t isa, size_t N)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), N(N) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), N(N) {}
     
     bool checkGridInterpolation(RTCGeometry geom, int primID, float u, float v, RTCBufferType bufferType, unsigned int bufferSlot, size_t N)
     {
@@ -2358,7 +2358,7 @@ namespace embree
     size_t N;
     
     InterpolateHairTest (std::string name, int64_t isa, size_t N)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), N(N) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), N(N) {}
     
     bool checkHairInterpolation(RTCGeometry geom, int primID, float u, float v, int v0, RTCBufferType bufferType, unsigned int bufferSlot, float* data, size_t N, size_t N_total)
     {
@@ -2465,7 +2465,7 @@ namespace embree
     RTCBuildQuality quality; 
 
     TriangleHitTest (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality, IntersectMode imode, IntersectVariant ivariant)
-      : VerifyApplication::IntersectTest(name,isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {}
+      : VerifyApplication::IntersectTest(std::move(name),isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {}
 
     inline Vec3fa uniformSampleTriangle(const Vec3fa &a, const Vec3fa &b, const Vec3fa &c, float &u, float& v)
     {
@@ -2552,7 +2552,7 @@ namespace embree
     RTCBuildQuality quality; 
 
     QuadHitTest (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality, IntersectMode imode, IntersectVariant ivariant)
-      : VerifyApplication::IntersectTest(name,isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {}
+      : VerifyApplication::IntersectTest(std::move(name),isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -2629,7 +2629,7 @@ namespace embree
     RTCBuildQuality quality; 
 
     RayMasksTest (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality, IntersectMode imode, IntersectVariant ivariant)
-      : VerifyApplication::IntersectTest(name,isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {}
+      : VerifyApplication::IntersectTest(std::move(name),isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -2698,7 +2698,7 @@ namespace embree
     GeometryType gtype;
 
     BackfaceCullingTest (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality, GeometryType gtype, IntersectMode imode, IntersectVariant ivariant)
-      : VerifyApplication::IntersectTest(name,isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality), gtype(gtype) {}
+      : VerifyApplication::IntersectTest(std::move(name),isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality), gtype(gtype) {}
     
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -2766,7 +2766,7 @@ namespace embree
     bool subdiv;
 
     IntersectionFilterTest (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality, bool subdiv, IntersectMode imode, IntersectVariant ivariant)
-      : VerifyApplication::IntersectTest(name,isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality), subdiv(subdiv) {}
+      : VerifyApplication::IntersectTest(std::move(name),isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality), subdiv(subdiv) {}
     
     static void intersectionFilterN(const RTCFilterFunctionNArguments* const args)
     {
@@ -2843,7 +2843,7 @@ namespace embree
     bool subdiv;
 
     InstancingTest (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality, bool subdiv, IntersectMode imode, IntersectVariant ivariant)
-      : VerifyApplication::IntersectTest(name,isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality), subdiv(subdiv) {
+      : VerifyApplication::IntersectTest(std::move(name),isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality), subdiv(subdiv) {
       }
 
     struct RayQueryContext {
@@ -2947,7 +2947,7 @@ namespace embree
     RTCBuildQuality quality;
 
     InstanceArrayTest (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality, IntersectMode imode, IntersectVariant ivariant)
-      : VerifyApplication::IntersectTest(name,isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {
+      : VerifyApplication::IntersectTest(std::move(name),isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {
       }
 
     struct RayQueryContext {
@@ -3162,7 +3162,7 @@ namespace embree
     RTCBuildQuality quality;
 
     InstanceArrayRandomTest (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality, IntersectMode imode, IntersectVariant ivariant)
-      : VerifyApplication::IntersectTest(name,isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {
+      : VerifyApplication::IntersectTest(std::move(name),isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {
       }
 
     struct RayQueryContext {
@@ -3449,7 +3449,7 @@ namespace embree
     RTCBuildQuality quality;
 
     InstanceArrayTestFormats (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality, IntersectMode imode, IntersectVariant ivariant)
-      : VerifyApplication::IntersectTest(name,isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {
+      : VerifyApplication::IntersectTest(std::move(name),isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {
       }
 
     struct RayQueryContext {
@@ -3559,7 +3559,7 @@ namespace embree
     static const size_t maxStreamSize = 100;
     
     InactiveRaysTest (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality, IntersectMode imode, IntersectVariant ivariant)
-      : VerifyApplication::IntersectTest(name,isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {}
+      : VerifyApplication::IntersectTest(std::move(name),isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {}
    
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -3618,7 +3618,7 @@ namespace embree
     static const size_t maxStreamSize = 30;
     
     WatertightTest (std::string name, int64_t isa, SceneFlags sflags, IntersectMode imode, std::string model, const Vec3fa& pos)
-      : VerifyApplication::IntersectTest(name,isa,imode,VARIANT_INTERSECT,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), model(model), pos(pos) {}
+      : VerifyApplication::IntersectTest(std::move(name),isa,imode,VARIANT_INTERSECT,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), model(std::move(model)), pos(pos) {}
     
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -3699,7 +3699,7 @@ namespace embree
     static const size_t maxStreamSize = 100;
     
     SmallTriangleHitTest (std::string name, int64_t isa, SceneFlags sflags, IntersectMode imode, const Vec3fa& pos, const float radius)
-      : VerifyApplication::IntersectTest(name,isa,imode,VARIANT_INTERSECT,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), pos(pos), radius(radius) {}
+      : VerifyApplication::IntersectTest(std::move(name),isa,imode,VARIANT_INTERSECT,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), pos(pos), radius(radius) {}
     
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -3765,7 +3765,7 @@ namespace embree
     static const size_t maxStreamSize = 100;
     
     RayAlignmentTest (std::string name, int64_t isa, SceneFlags sflags, IntersectMode imode, std::string model)
-      : VerifyApplication::IntersectTest(name,isa,imode,VARIANT_INTERSECT,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), model(model) {}
+      : VerifyApplication::IntersectTest(std::move(name),isa,imode,VARIANT_INTERSECT,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), model(std::move(model)) {}
     
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -3816,7 +3816,7 @@ namespace embree
     RTCBuildQuality quality;
     
     NaNTest (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality, IntersectMode imode, IntersectVariant ivariant)
-      : VerifyApplication::IntersectTest(name,isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality)  {}
+      : VerifyApplication::IntersectTest(std::move(name),isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality)  {}
     
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -3887,7 +3887,7 @@ namespace embree
     RTCBuildQuality quality;
     
     InfTest (std::string name, int64_t isa, SceneFlags sflags, RTCBuildQuality quality, IntersectMode imode, IntersectVariant ivariant)
-      : VerifyApplication::IntersectTest(name,isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {}
+      : VerifyApplication::IntersectTest(std::move(name),isa,imode,ivariant,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), quality(quality) {}
    
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -3972,7 +3972,7 @@ namespace embree
     SceneFlags sflags; 
 
     PointQueryAPICallsTest (std::string name, int64_t isa, SceneFlags sflags)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication *state, bool silent)
     {
@@ -4233,7 +4233,7 @@ namespace embree
     std::string tri_accel;
 
     PointQueryTest (std::string name, int64_t isa, SceneFlags sflags, std::string tri_accel = "")
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), tri_accel(tri_accel) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), tri_accel(std::move(tri_accel)) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -4328,7 +4328,7 @@ namespace embree
     std::string tri_accel;
 
     PointQueryMotionBlurTest (std::string name, int64_t isa, SceneFlags sflags, std::string tri_accel = "")
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), tri_accel(tri_accel) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), sflags(sflags), tri_accel(std::move(tri_accel)) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -4474,7 +4474,7 @@ namespace embree
   struct GeometryStateTest : public VerifyApplication::Test
   {
     GeometryStateTest (std::string name, int64_t isa)
-      : VerifyApplication::Test (name, isa, VerifyApplication::TEST_SHOULD_PASS) {}
+      : VerifyApplication::Test (std::move(name), isa, VerifyApplication::TEST_SHOULD_PASS) {}
     
     VerifyApplication::TestReturnValue run (VerifyApplication* state, bool silent)
     {
@@ -4557,7 +4557,7 @@ namespace embree
 	  };
 
 	  SceneCheckModifiedGeometryTest (std::string name, int64_t isa) 
-		: VerifyApplication::Test(name, isa, VerifyApplication::TEST_SHOULD_PASS)
+		: VerifyApplication::Test(std::move(name), isa, VerifyApplication::TEST_SHOULD_PASS)
 	  {}
 
 	  VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
@@ -4638,7 +4638,7 @@ namespace embree
     };
     
     SphereFilterMultiHitTest (std::string name, int64_t isa) 
-      : VerifyApplication::Test(name, isa, VerifyApplication::TEST_SHOULD_PASS)
+      : VerifyApplication::Test(std::move(name), isa, VerifyApplication::TEST_SHOULD_PASS)
     {}
     
     void createSphere(RTCDevice device, RTCScene scene, float x, float y, float z, float r)
@@ -5304,7 +5304,7 @@ namespace embree
     std::vector<thread_t> threads;
     
     IntensiveRegressionTest (std::string name, int64_t isa, thread_func func, int mode, float intensity)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), func(func), mode(mode), intensity(intensity) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), func(func), mode(mode), intensity(intensity) {}
     
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -5382,7 +5382,7 @@ namespace embree
     std::vector<IntersectMode> intersectModes;
     
     MemoryMonitorTest (std::string name, int64_t isa, thread_func func, float intensity)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS), func(func), intensity(intensity) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS), func(func), intensity(intensity) {}
     
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -5441,7 +5441,7 @@ namespace embree
   struct ParallelForExceptionTest1 : public VerifyApplication::Test
   {
     ParallelForExceptionTest1 (std::string name, int64_t isa)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -5469,7 +5469,7 @@ namespace embree
   struct ParallelForExceptionTest2 : public VerifyApplication::Test
   {
     ParallelForExceptionTest2 (std::string name, int64_t isa)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -5502,7 +5502,7 @@ namespace embree
   struct ParallelForExceptionTest3 : public VerifyApplication::Test
   {
     ParallelForExceptionTest3 (std::string name, int64_t isa)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -5534,7 +5534,7 @@ namespace embree
   struct ParallelForExceptionTest4 : public VerifyApplication::Test
   {
     ParallelForExceptionTest4 (std::string name, int64_t isa)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -5566,7 +5566,7 @@ namespace embree
   struct ParallelForExceptionTest5 : public VerifyApplication::Test
   {
     ParallelForExceptionTest5 (std::string name, int64_t isa)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -5609,7 +5609,7 @@ namespace embree
   struct ParallelForExceptionTest6 : public VerifyApplication::Test
   {
     ParallelForExceptionTest6 (std::string name, int64_t isa)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -5648,7 +5648,7 @@ namespace embree
   struct ParallelForExceptionTest7 : public VerifyApplication::Test
   {
     ParallelForExceptionTest7 (std::string name, int64_t isa)
-      : VerifyApplication::Test(name,isa,VerifyApplication::TEST_SHOULD_PASS) {}
+      : VerifyApplication::Test(std::move(name),isa,VerifyApplication::TEST_SHOULD_PASS) {}
 
     VerifyApplication::TestReturnValue run(VerifyApplication* state, bool silent)
     {
@@ -5772,7 +5772,7 @@ namespace embree
 	static const size_t numTilesY = height / tileSizeY;
     
     CoherentRaysBenchmark (std::string name, int64_t isa, GeometryType gtype, SceneFlags sflags, RTCBuildQuality quality, IntersectMode imode, IntersectVariant ivariant, size_t numPhi)
-      : ParallelIntersectBenchmark(name,isa,numTilesX*numTilesY,1), gtype(gtype), sflags(sflags), quality(quality), imode(imode), ivariant(ivariant), numPhi(numPhi) {}
+      : ParallelIntersectBenchmark(std::move(name),isa,numTilesX*numTilesY,1), gtype(gtype), sflags(sflags), quality(quality), imode(imode), ivariant(ivariant), numPhi(numPhi) {}
     
     size_t setNumPrimitives(size_t N) 
     { 
@@ -5934,7 +5934,7 @@ namespace embree
     static const size_t deltaRays = 1024;
     
     IncoherentRaysBenchmark (std::string name, int64_t isa, GeometryType gtype, SceneFlags sflags, RTCBuildQuality quality, IntersectMode imode, IntersectVariant ivariant, size_t numPhi)
-      : ParallelIntersectBenchmark(name,isa,numRays,deltaRays), gtype(gtype), sflags(sflags), quality(quality), imode(imode), ivariant(ivariant), numPhi(numPhi), device(nullptr)  {}
+      : ParallelIntersectBenchmark(std::move(name),isa,numRays,deltaRays), gtype(gtype), sflags(sflags), quality(quality), imode(imode), ivariant(ivariant), numPhi(numPhi), device(nullptr)  {}
 
     size_t setNumPrimitives(size_t N) 
     { 
@@ -7148,4 +7148,3 @@ int main(int argc, char** argv)
 
   return code;
 }
-

--- a/tutorials/verify/verify.h
+++ b/tutorials/verify/verify.h
@@ -73,8 +73,8 @@ namespace embree
     {
     public:
       const std::string unit;
-      Benchmark (const std::string& name, int64_t isa, const std::string& unit, bool higher_is_better, size_t max_attempts)
-        : Test(name,isa,BENCHMARK,false), unit(unit), numThreads(getNumberOfLogicalThreads()), higher_is_better(higher_is_better), max_attempts(max_attempts) {}
+      Benchmark (std::string name, int64_t isa, std::string unit, bool higher_is_better, size_t max_attempts)
+        : Test(std::move(name),isa,BENCHMARK,false), unit(std::move(unit)), numThreads(getNumberOfLogicalThreads()), higher_is_better(higher_is_better), max_attempts(max_attempts) {}
       
       virtual size_t setNumPrimitives(size_t N) { return 0; }
       virtual void setNumThreads(size_t N) 
@@ -100,14 +100,14 @@ namespace embree
     struct TestGroup : public Test
     {
       TestGroup (std::string name, bool silent, bool parallel, bool enabled = true)
-        : Test(name,0,TEST_GROUP,enabled), silent(silent), parallel(parallel) {}
+        : Test(std::move(name),0,TEST_GROUP,enabled), silent(silent), parallel(parallel) {}
 
     public:
-      void add(Ref<Test> test) {
+      void add(const Ref<Test>& test) {
         tests.push_back(test);
       }
 
-      std::string extend_prefix(std::string prefix) const {
+      std::string extend_prefix(const std::string& prefix) const {
         return (name != "") ? prefix + name + "." : prefix;
       }
       
@@ -133,16 +133,16 @@ namespace embree
   public:
 
     VerifyApplication ();
-    void prefix_test_names(Ref<Test> test, std::string prefix = "");
+    void prefix_test_names(Ref<Test> test, const std::string& prefix = "");
     bool update_tests(Ref<Test> test);
     void print_tests(Ref<Test> test, size_t depth);
     void print_ctests(Ref<Test> test, size_t depth);
     template<typename Function> 
       void map_tests(Ref<Test> test, const Function& f);
-    void enable_disable_all_tests(Ref<Test> test, bool enabled);
-    size_t enable_disable_some_tests(Ref<Test> test, std::string regex, bool enabled);
+    void enable_disable_all_tests(const Ref<Test>& test, bool enabled);
+    size_t enable_disable_some_tests(const Ref<Test>& test, std::string regex, bool enabled);
      template<typename Closure>
-       void plot(std::vector<Ref<Benchmark>> benchmarks, const FileName outFileName, std::string xlabel, size_t startN, size_t endN, float f, size_t dn, const Closure& test);
+       void plot(std::vector<Ref<Benchmark>> benchmarks, const FileName& outFileName, const std::string& xlabel, size_t startN, size_t endN, float f, size_t dn, const Closure& test);
     FileName parse_benchmark_list(Ref<ParseStream> cin, std::vector<Ref<Benchmark>>& benchmarks);
     int main(int argc, char** argv);
     

--- a/tutorials/verify/verify.h
+++ b/tutorials/verify/verify.h
@@ -5,6 +5,7 @@
  * always compile without any internal Embree specific stuff. */
 #include "../../include/embree4/rtcore.h"
 #include "../../include/embree4/rtcore_ray.h"
+#include <utility>
 RTC_NAMESPACE_USE
 
 /* now we include all Embree internal files we need for testing */
@@ -26,7 +27,7 @@ namespace embree
     struct Test : public RefCount
     {
       Test (std::string name, int64_t isa, TestType ty, bool enabled = true) 
-        : name(name), isa(isa), ty(ty), enabled(enabled), ignoreFailure(false) 
+        : name(std::move(name)), isa(isa), ty(ty), enabled(enabled), ignoreFailure(false)
       {
         RandomSampler_init(sampler,0x23F67E21);
       }
@@ -122,7 +123,7 @@ namespace embree
     struct IntersectTest : public Test
     {
       IntersectTest (std::string name, int64_t isa, IntersectMode imode, IntersectVariant ivariant, TestType ty = TEST_SHOULD_PASS)
-        : Test(name,isa,ty), imode(imode), ivariant(ivariant) {}
+        : Test(std::move(name),isa,ty), imode(imode), ivariant(ivariant) {}
 
     public:
       IntersectMode imode;


### PR DESCRIPTION
Apply move-aware string forwarding in verify test constructors
Resolve Coverity COPY_INSTEAD_OF_MOVE findings